### PR TITLE
Add frontend environment variable configuration

### DIFF
--- a/frontend/.env.template
+++ b/frontend/.env.template
@@ -1,0 +1,8 @@
+# .env.template
+# Copy this file to .env and fill in your values
+
+# API Configuration
+EXPO_PUBLIC_API_URL=http://YOUR_LOCAL_IP:8080
+
+# Google OAuth iOS Client ID
+EXPO_PUBLIC_IOS_CLIENT_ID=637676049223-kg32deotit3muuhi3j1q253vfhotnoai.apps.googleusercontent.com

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -31,6 +31,9 @@ yarn-error.*
 
 # local env files
 .env*.local
+.env
+!.env.template
+
 
 # typescript
 *.tsbuildinfo

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,65 +1,25 @@
-# Starter Template with React Navigation
+# This is our frontend
 
-This is a minimal starter template for React Native apps using Expo and React Navigation.
+## How to run
 
-It includes the following:
+1. Set up environment variables
 
-- Example [Native Stack](https://reactnavigation.org/docs/native-stack-navigator) with a nested [Bottom Tab](https://reactnavigation.org/docs/bottom-tab-navigator)
-- Web support with [React Native for Web](https://necolas.github.io/react-native-web/)
-- TypeScript support and configured for React Navigation
-- Automatic [deep link](https://reactnavigation.org/docs/deep-linking) and [URL handling configuration](https://reactnavigation.org/docs/configuring-links)
-- Theme support [based on system appearance](https://reactnavigation.org/docs/themes/#using-the-operating-system-preferences)
-- Expo [Development Build](https://docs.expo.dev/develop/development-builds/introduction/) with [Continuous Native Generation](https://docs.expo.dev/workflow/continuous-native-generation/)
+```bash
+cp .env.template .env
+```
 
-## Getting Started
+Edit `.env` with the secret variables 🤫 🤐
 
-1. Create a new project using this template:
+2. Install dependencies
 
-   ```sh
-   npx create-expo-app@latest --template react-navigation/template
-   ```
+```bash
+npm install
+```
 
-2. Edit the `app.json` file to configure the `name`, `slug`, `scheme` and bundle identifiers (`ios.bundleIdentifier` and `android.bundleIdentifier`) for your app.
+3. Start the app
 
-3. Edit the `src/App.tsx` file to start working on your app.
+```bash
+npm start
+```
 
-## Running the app
-
-- Install the dependencies:
-
-  ```sh
-  npm install
-  ```
-
-- Start the development server:
-
-  ```sh
-  npm start
-  ```
-
-- Build and run iOS and Android development builds:
-
-  ```sh
-  npm run ios
-  # or
-  npm run android
-  ```
-
-- In the terminal running the development server, press `i` to open the iOS simulator, `a` to open the Android device or emulator, or `w` to open the web browser.
-
-## Notes
-
-This project uses a [development build](https://docs.expo.dev/develop/development-builds/introduction/) and cannot be run with [Expo Go](https://expo.dev/go). To run the app with Expo Go, edit the `package.json` file, remove the `expo-dev-client` package and `--dev-client` flag from the `start` script.
-
-We highly recommend using the development builds for normal development and testing.
-
-The `ios` and `android` folder are gitignored in the project by default as they are automatically generated during the build process ([Continuous Native Generation](https://docs.expo.dev/workflow/continuous-native-generation/)). This means that you should not edit these folders directly and use [config plugins](https://docs.expo.dev/config-plugins/) instead. However, if you need to edit these folders, you can remove them from the `.gitignore` file so that they are tracked by git.
-
-## Resources
-
-- [React Navigation documentation](https://reactnavigation.org/)
-- [Expo documentation](https://docs.expo.dev/)
-
----
-
-Demo assets are from [lucide.dev](https://lucide.dev/)
+![Image](https://media1.tenor.com/m/lZmRtXcNlScAAAAd/rizzler-boom-rizzler-dance.gif)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,8 +30,7 @@ export function App() {
   const theme = colorScheme === "dark" ? DarkTheme : DefaultTheme;
   useEffect(() => {
     GoogleSignin.configure({
-      iosClientId:
-        "637676049223-kg32deotit3muuhi3j1q253vfhotnoai.apps.googleusercontent.com",
+      iosClientId: process.env.EXPO_PUBLIC_IOS_CLIENT_ID,
       profileImageSize: 150,
     });
   });

--- a/frontend/src/navigation/screens/Login.tsx
+++ b/frontend/src/navigation/screens/Login.tsx
@@ -28,8 +28,7 @@ export function LoginScreen() {
       if (isSuccessResponse(respone)) {
         const { idToken, user } = respone.data;
         const backendResponse = await fetch(
-          //INSERT YOUR BACKEND URL HERE (e.g., localhost or your server's IP) spring boot server
-          "http://10.54.49.13:8080/api/auth/google",
+          `${process.env.EXPO_PUBLIC_API_URL}/api/auth/google`,
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
# Add environment variable configuration

## Reason
These variables will change in production and even from develop to developer so we need a way to deal with that so we dont have to worry about commiting our changes. 

## Changes
- Added `.env.template` for environment setup (This template shows what to put in the .env)
- Updated `.gitignore` to exclude `.env` and `.env*.local` 
- Refactored `LoginScreen` to use `EXPO_PUBLIC_API_URL` from environment variables
- Refactored `App` screen to use `EXPO_PUBLIC_IOS_CLIENT_ID` from environment variables
- Added setup instructions to README

## Setup for reviewers
```bash
cp .env.template .env
# Edit .env with your local IP and ios client id
npm start
```