### PR TITLE
Fix timezone/timing bugs by passing client localDate to date-based endpoints

### DIFF
--- a/backend/src/main/java/com/gearfitness/gear_api/controller/AppUserController.java
+++ b/backend/src/main/java/com/gearfitness/gear_api/controller/AppUserController.java
@@ -53,7 +53,8 @@ public class AppUserController {
    */
   @GetMapping("/me/profile")
   public ResponseEntity<UserProfileDTO> getCurrentUserEnhancedProfile(
-    @RequestHeader("Authorization") String authHeader
+    @RequestHeader("Authorization") String authHeader,
+    @RequestParam(required = false) String localDate
   ) {
     try {
       String token = authHeader.substring(7); // Remove "Bearer " prefix
@@ -61,7 +62,8 @@ public class AppUserController {
 
       UserProfileDTO profile = userService.getEnhancedUserProfile(
         userId,
-        userId
+        userId,
+        localDate
       );
       return ResponseEntity.ok(profile);
     } catch (Exception e) {
@@ -99,7 +101,8 @@ public class AppUserController {
   @GetMapping("/{username}")
   public ResponseEntity<?> getUserByUsername(
     @PathVariable String username,
-    @RequestHeader(value = "Authorization", required = false) String authHeader
+    @RequestHeader(value = "Authorization", required = false) String authHeader,
+    @RequestParam(required = false) String localDate
   ) {
     try {
       UUID viewingUserId = null;
@@ -116,7 +119,8 @@ public class AppUserController {
 
       UserProfileDTO profile = userService.getEnhancedUserProfileByUsername(
         username,
-        viewingUserId
+        viewingUserId,
+        localDate
       );
       // TODO: Filter response based on privacy settings
       return ResponseEntity.ok(profile);

--- a/backend/src/main/java/com/gearfitness/gear_api/controller/RoutineController.java
+++ b/backend/src/main/java/com/gearfitness/gear_api/controller/RoutineController.java
@@ -119,7 +119,10 @@ public class RoutineController {
       String token = authHeader.substring(7);
       UUID userId = jwtService.extractUserId(token);
 
-      List<RoutineDTO> routines = routineService.getTodaysRoutines(userId, localDate);
+      List<RoutineDTO> routines = routineService.getTodaysRoutines(
+        userId,
+        localDate
+      );
       return ResponseEntity.ok(routines);
     } catch (Exception e) {
       e.printStackTrace();

--- a/backend/src/main/java/com/gearfitness/gear_api/controller/RoutineController.java
+++ b/backend/src/main/java/com/gearfitness/gear_api/controller/RoutineController.java
@@ -112,13 +112,14 @@ public class RoutineController {
    */
   @GetMapping("/today")
   public ResponseEntity<List<RoutineDTO>> getTodaysRoutines(
-    @RequestHeader("Authorization") String authHeader
+    @RequestHeader("Authorization") String authHeader,
+    @RequestParam(required = false) String localDate
   ) {
     try {
       String token = authHeader.substring(7);
       UUID userId = jwtService.extractUserId(token);
 
-      List<RoutineDTO> routines = routineService.getTodaysRoutines(userId);
+      List<RoutineDTO> routines = routineService.getTodaysRoutines(userId, localDate);
       return ResponseEntity.ok(routines);
     } catch (Exception e) {
       e.printStackTrace();

--- a/backend/src/main/java/com/gearfitness/gear_api/controller/WorkoutController.java
+++ b/backend/src/main/java/com/gearfitness/gear_api/controller/WorkoutController.java
@@ -140,14 +140,16 @@ public class WorkoutController {
   public ResponseEntity<List<DailyVolumeDTO>> getDailyVolume(
     @PathVariable UUID userId,
     @RequestParam(defaultValue = "2") int weeks,
-    @RequestParam(defaultValue = "SUNDAY") String weekStartDay
+    @RequestParam(defaultValue = "SUNDAY") String weekStartDay,
+    @RequestParam(required = false) String localDate
   ) {
     try {
       DayOfWeek startDay = DayOfWeek.valueOf(weekStartDay.toUpperCase());
       List<DailyVolumeDTO> dailyVolume = workoutService.getDailyVolume(
         userId,
         weeks,
-        startDay
+        startDay,
+        localDate
       );
       return ResponseEntity.ok(dailyVolume);
     } catch (IllegalArgumentException e) {

--- a/backend/src/main/java/com/gearfitness/gear_api/service/AppUserService.java
+++ b/backend/src/main/java/com/gearfitness/gear_api/service/AppUserService.java
@@ -193,7 +193,10 @@ public class AppUserService {
   /**
    * Calculate workout statistics for a user
    */
-  private WorkoutStatsDTO calculateWorkoutStats(AppUser user, String localDate) {
+  private WorkoutStatsDTO calculateWorkoutStats(
+    AppUser user,
+    String localDate
+  ) {
     // Total workouts
     long totalWorkouts = workoutRepository.countByUser(user);
 

--- a/backend/src/main/java/com/gearfitness/gear_api/service/AppUserService.java
+++ b/backend/src/main/java/com/gearfitness/gear_api/service/AppUserService.java
@@ -115,13 +115,14 @@ public class AppUserService {
    */
   public UserProfileDTO getEnhancedUserProfile(
     UUID userId,
-    UUID viewingUserId
+    UUID viewingUserId,
+    String localDate
   ) {
     AppUser user = userRepository
       .findById(userId)
       .orElseThrow(() -> new RuntimeException("User not found"));
 
-    return buildEnhancedProfile(user, viewingUserId);
+    return buildEnhancedProfile(user, viewingUserId, localDate);
   }
 
   /**
@@ -130,13 +131,14 @@ public class AppUserService {
    */
   public UserProfileDTO getEnhancedUserProfileByUsername(
     String username,
-    UUID viewingUserId
+    UUID viewingUserId,
+    String localDate
   ) {
     AppUser user = userRepository
       .findByUsername(username)
       .orElseThrow(() -> new RuntimeException("User not found"));
 
-    return buildEnhancedProfile(user, viewingUserId);
+    return buildEnhancedProfile(user, viewingUserId, localDate);
   }
 
   /**
@@ -144,9 +146,10 @@ public class AppUserService {
    */
   private UserProfileDTO buildEnhancedProfile(
     AppUser user,
-    UUID viewingUserId
+    UUID viewingUserId,
+    String localDate
   ) {
-    WorkoutStatsDTO workoutStats = calculateWorkoutStats(user);
+    WorkoutStatsDTO workoutStats = calculateWorkoutStats(user, localDate);
     long followersCount = followRepository.countByFolloweeAndStatus(
       user,
       Follow.FollowStatus.ACCEPTED
@@ -190,12 +193,14 @@ public class AppUserService {
   /**
    * Calculate workout statistics for a user
    */
-  private WorkoutStatsDTO calculateWorkoutStats(AppUser user) {
+  private WorkoutStatsDTO calculateWorkoutStats(AppUser user, String localDate) {
     // Total workouts
     long totalWorkouts = workoutRepository.countByUser(user);
 
     // Get start and end of current week (Monday to Sunday)
-    LocalDate today = LocalDate.now();
+    LocalDate today = (localDate != null && !localDate.isBlank())
+      ? LocalDate.parse(localDate)
+      : LocalDate.now();
     LocalDate startOfWeek = today.with(
       TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)
     );
@@ -219,7 +224,7 @@ public class AppUserService {
     );
 
     // Calculate streak (consecutive completed weeks with 5+ distinct workout days)
-    int workoutStreak = calculateWorkoutStreak(user);
+    int workoutStreak = calculateWorkoutStreak(user, today);
 
     // Count distinct workout days in the current week
     List<Workout> currentWeekWorkouts =
@@ -250,8 +255,7 @@ public class AppUserService {
    * 2. Count all distinct workout days from the Monday after that failed week through today.
    *    If no week failed, count all distinct workout days ever.
    */
-  private int calculateWorkoutStreak(AppUser user) {
-    LocalDate today = LocalDate.now();
+  private int calculateWorkoutStreak(AppUser user, LocalDate today) {
     LocalDate currentWeekMonday = today.with(
       TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)
     );

--- a/backend/src/main/java/com/gearfitness/gear_api/service/RoutineService.java
+++ b/backend/src/main/java/com/gearfitness/gear_api/service/RoutineService.java
@@ -139,8 +139,11 @@ public class RoutineService {
     return toRoutineDTO(routine);
   }
 
-  public List<RoutineDTO> getTodaysRoutines(UUID userId) {
-    DayOfWeek today = LocalDate.now().getDayOfWeek();
+  public List<RoutineDTO> getTodaysRoutines(UUID userId, String localDate) {
+    LocalDate date = (localDate != null && !localDate.isBlank())
+      ? LocalDate.parse(localDate)
+      : LocalDate.now();
+    DayOfWeek today = date.getDayOfWeek();
 
     return routineRepository
       .findByUser_UserIdOrderByCreatedAtDesc(userId)

--- a/backend/src/main/java/com/gearfitness/gear_api/service/WorkoutService.java
+++ b/backend/src/main/java/com/gearfitness/gear_api/service/WorkoutService.java
@@ -191,7 +191,8 @@ public class WorkoutService {
   public List<DailyVolumeDTO> getDailyVolume(
     UUID userId,
     int numberOfWeeks,
-    DayOfWeek weekStartDay
+    DayOfWeek weekStartDay,
+    String localDate
   ) {
     List<Workout> workouts = workoutRepository.findByUser_UserId(userId);
 
@@ -202,7 +203,10 @@ public class WorkoutService {
     // Calculate date range
     // Extend endDate to the end of the current week (Saturday) to ensure full week
     // is displayed
-    LocalDate endDate = LocalDate.now().with(
+    LocalDate referenceDate = (localDate != null && !localDate.isBlank())
+      ? LocalDate.parse(localDate)
+      : LocalDate.now();
+    LocalDate endDate = referenceDate.with(
       TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY)
     );
 

--- a/frontend/src/api/routineService.ts
+++ b/frontend/src/api/routineService.ts
@@ -1,5 +1,6 @@
 import apiClient from "./apiClient";
 import { Routine } from "./types";
+import { getCurrentLocalDateString } from "../utils/date";
 
 export async function createRoutineFromWorkout(
   workoutId: string,
@@ -25,7 +26,9 @@ export async function getRoutineDetail(routineId: string): Promise<Routine> {
 }
 
 export async function getTodaysRoutines(): Promise<Routine[]> {
-  const { data } = await apiClient.get<Routine[]>("/routines/today");
+  const { data } = await apiClient.get<Routine[]>("/routines/today", {
+    params: { localDate: getCurrentLocalDateString() },
+  });
   return data;
 }
 

--- a/frontend/src/api/userService.ts
+++ b/frontend/src/api/userService.ts
@@ -6,14 +6,19 @@ import {
   FollowResponse,
   UsernameAvailabilityResponse,
 } from "./types";
+import { getCurrentLocalDateString } from "../utils/date";
 
 export async function getCurrentUserProfile(): Promise<UserProfile> {
-  const { data } = await apiClient.get("/users/me/profile");
+  const { data } = await apiClient.get("/users/me/profile", {
+    params: { localDate: getCurrentLocalDateString() },
+  });
   return data;
 }
 
 export async function getUserProfile(username: string): Promise<UserProfile> {
-  const { data } = await apiClient.get(`/users/${username}`);
+  const { data } = await apiClient.get(`/users/${username}`, {
+    params: { localDate: getCurrentLocalDateString() },
+  });
   return data;
 }
 

--- a/frontend/src/api/workoutService.ts
+++ b/frontend/src/api/workoutService.ts
@@ -11,6 +11,7 @@ import {
   WorkoutDetail,
   PersonalRecord,
 } from "./types";
+import { getCurrentLocalDateString } from "../utils/date";
 
 export interface WorkoutSubmission {
   name: string;
@@ -73,7 +74,7 @@ export async function getWeeklyVolume(
   const { data } = await apiClient.get(
     `/workouts/user/${userId}/weekly-volume`,
     {
-      params: { weeks },
+      params: { weeks, localDate: getCurrentLocalDateString() },
     },
   );
   return data;
@@ -90,7 +91,7 @@ export async function getDailyVolume(
   const { data } = await apiClient.get(
     `/workouts/user/${userId}/daily-volume`,
     {
-      params: { weeks, weekStartDay },
+      params: { weeks, weekStartDay, localDate: getCurrentLocalDateString() },
     },
   );
   return data;


### PR DESCRIPTION
### Summary

**Backend:** Added optional `localDate` query param to “today/this week” style endpoints so calculations can be anchored to the user’s local date (instead of server `LocalDate.now()`), affecting:
* `GET /users/me/profile` and `GET /users/{username}` enhanced profile/stats (incl. streak/week stats)
* `GET /routines/today`
* `GET /workouts/user/{userId}/daily-volume`

**Frontend:** Updated API calls to include `localDate: getCurrentLocalDateString()` (`YYYY-MM-DD`) so the server uses the client’s local calendar day for the above endpoints.

---

### Test plan

1. **Timezone Offset:** Set device timezone to a far offset (e.g., Pacific vs. UTC+12), then verify “today’s routines,” profile weekly stats/streak, and daily volume don’t shift by a day around midnight.
2. **Endpoint Validation:** Hit the endpoints with and without `localDate` and confirm:
    * **With `localDate`:** Results align with the provided date.
    * **Without it:** Behavior remains unchanged (defaults to server date).